### PR TITLE
Allows higher versions of symfony/yaml for compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": ">=5.6",
-        "symfony/yaml":                   "^2.8.11|^3.2",
+        "symfony/yaml":                   "^2.8.11|~3.2",
         "symfony/console":                "^2.8.11|^3.2",
         "symfony/filesystem":             "^2.8.11|^3.2",
         "dflydev/dot-access-data":        "^1.1.0"


### PR DESCRIPTION
I've been trying to get the Acquia PHP SDK compatible with BLT but it looks like there are some composer conflicts.
From what I understand, symfony/dependency-injection 3.3 is only compatible with symfony/yaml >=3.3. I also can't drop the version down to 3.2 because symfony/config (3.3) in BLT is incompatible with that version.
Looking at the composer.lock, I think this library has the requirement for 3.2 so I've changed ^ to ~ to allow 3.3 of symfony/yaml to be installed.