### PR TITLE
Allow Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
   "type": "library",
   "require": {
     "php": ">=8.0",
-    "symfony/yaml": "^6 || ^7",
-    "symfony/console": "^6 || ^7",
-    "symfony/filesystem": "^6 || ^7",
+    "symfony/yaml": "^6 || ^7 || ^8",
+    "symfony/console": "^6 || ^7 || ^8",
+    "symfony/filesystem": "^6 || ^7 || ^8",
     "dflydev/dot-access-data": "^3"
   },
   "license": "MIT",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "302f2d0606553ff3cb8ee5aef485960f",
+    "content-hash": "2bbf22a08e8f8469696be199831882cc",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -3538,15 +3538,15 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.0"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2.18"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Widen symfony/* constraints to allow ^8.

No code changes needed — the APIs used by this package are unchanged in Symfony 8.

Ref: https://github.com/drush-ops/drush/issues/6536